### PR TITLE
Migrate from MoviePy v1.x to v2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-moviepy = "~=1.0.3"
-tqdm = "~=4.60.0"
+moviepy = "~=2.2.1"
+numpy = "~=2.3.1"
+tqdm = "~=4.67.1"
 
 [tool.poetry.dev-dependencies]
 coverage = "~=5.3.0"


### PR DESCRIPTION
This PR updates the code inside [`jumpcutter/clip.py`](jumpcutter/clip.py) to use MoviePy v2.x instead of the deprecated v1.x version. Also adds `numpy` to the list of dependencies inside [`pyproject.toml`](pyproject.toml).